### PR TITLE
fix #1

### DIFF
--- a/types/plugin/timezone.d.ts
+++ b/types/plugin/timezone.d.ts
@@ -9,7 +9,7 @@ declare module 'dayjs' {
   }
 
   interface DayjsTimezone {
-    (date: ConfigType, timezone: string): Dayjs
+      (date: ConfigType, timezone?: string): Dayjs
     guess(): string
     setDefault(timezone?: string): void
   }


### PR DESCRIPTION
允许DayjsTimezone接口的第一个参数date为可选参数