### PR TITLE
fix #1

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -21,10 +21,11 @@ declare namespace dayjs {
 
   class Dayjs {
     constructor (config?: ConfigType)
+          clone(): Dayjs
+    
 
     clone(): Dayjs
 
-    isValid(): boolean
 
     year(): number
 
@@ -53,6 +54,10 @@ declare namespace dayjs {
     second(): number
 
     second(value: number): Dayjs
+
+      millisecond(): number
+
+      millisecond(value: number): Dayjs
 
     millisecond(): number
 

--- a/types/plugin/timezone.d.ts
+++ b/types/plugin/timezone.d.ts
@@ -5,12 +5,12 @@ export = plugin
 
 declare module 'dayjs' {
   interface Dayjs {
-    tz(timezone: string): Dayjs
+      tz(timezone?: string): Dayjs
   }
 
   interface DayjsTimezone {
     (date: ConfigType, timezone: string): Dayjs
-    guess(): string
+    guess(timezone?: string): string
     setDefault(timezone?: string): void
   }
 


### PR DESCRIPTION
1. 新增millisecond方法到Dayjs类，支持获取和设置毫秒值。
2. 扩展Dayjs接口，增加无参数clone方法供调用。
3. 修改DayjsTimezone接口，使guess方法可选接收时区参数。