### PR TITLE
fix bug itcoffee

### DIFF
--- a/types/plugin/timezone.d.ts
+++ b/types/plugin/timezone.d.ts
@@ -5,13 +5,13 @@ export = plugin
 
 declare module 'dayjs' {
   interface Dayjs {
-    tz(timezone: string): Dayjs
+      tz(timezone?: string): Dayjs
   }
 
   interface DayjsTimezone {
-    (date: ConfigType, timezone: string): Dayjs
+      (date: ConfigType, timezone?: string): Dayjs
     guess(): string
-    setDefault(timezone?: string): void
+    setDefault(timezone: string): void
   }
 
   const tz: DayjsTimezone


### PR DESCRIPTION
1. 为Dayjs和DayjsTimezone接口的方法tz添加可选参数，使它们可以不传入时区字符串。
fix by itcoffee