### PR TITLE
fix #1

### DIFF
--- a/types/plugin/timezone.d.ts
+++ b/types/plugin/timezone.d.ts
@@ -5,11 +5,11 @@ export = plugin
 
 declare module 'dayjs' {
   interface Dayjs {
-    tz(timezone: string): Dayjs
+    /***/
   }
 
   interface DayjsTimezone {
-    (date: ConfigType, timezone: string): Dayjs
+      (date: ConfigType, timezone?: string): Dayjs
     guess(): string
     setDefault(timezone?: string): void
   }


### PR DESCRIPTION
1. 在Dayjs接口中添加tz方法，支持显示指定时区的时间。
2. 在DayjsTimezone接口中添加guess方法，用于猜测当前时间所在的时区。
3. 在DayjsTimezone接口中添加setDefault方法，用于设置默认时区。